### PR TITLE
Fixed SAP RFC Error: RFC_INVALID_HANDLE 

### DIFF
--- a/src/SapCo2/SapCo2.Core/Abstract/RfcFunctionBase.cs
+++ b/src/SapCo2/SapCo2.Core/Abstract/RfcFunctionBase.cs
@@ -46,6 +46,11 @@ namespace SapCo2.Core.Abstract
 
         public virtual void Dispose()
         {
+            if (_functionHandle == IntPtr.Zero)
+            {
+                return;
+            }
+
             RfcResultCodes resultCode = _interop.DestroyFunction(_functionHandle, out RfcErrorInfo errorInfo);
             resultCode.ThrowOnError(errorInfo);
         }


### PR DESCRIPTION
```
SapCo2.Wrapper.Exception.RfcException: SAP RFC Error: RFC_INVALID_HANDLE with message: An invalid handle 'RFC_FUNCTION_HANDLE' was passed to the API call
   at SapCo2.Wrapper.Extension.RfcResultCodeExtensions.ThrowOnError(RfcResultCodes resultCode, RfcErrorInfo errorInfo, Action beforeThrow)
   at SapCo2.Core.Abstract.RfcFunctionBase.Dispose()
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceProviderEngineScope.DisposeAsync()
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Http.Features.RequestServicesFeature.<DisposeAsync>g__Awaited|9_0(RequestServicesFeature servicesFeature, ValueTask vt)
   at Microsoft.AspNetCore.Server.IIS.Core.IISHttpContext.FireOnCompleted()
```
   
   Startup da proje ayağa kalkarken dependency injection Dispose metodunu çağırdığında sessizce patlıyordu.

   _functionHandle değişkeninin sıfır konumunda olduğu kontrol edilerek çözüldü.